### PR TITLE
Bump reuse-action from v3 to v5

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -12,5 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v3
-
+      uses: fsfe/reuse-action@v5


### PR DESCRIPTION
Meanwhile, reuse-action v3 produces inconsistent results compared to running `reuse lint` locally. Therefore it would be good to bump it.