### PR TITLE
Revert modifications to Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The LICENSE includes an appendix about how to apply the license terms. This should not have been modified.

For reference see the upstream LICENSE[^1] and related changes[^2] from the Kubernetes project.

[^1]: https://github.com/SAP/repository-template/blob/main/LICENSE#L189
[^2]: https://github.com/kubernetes/kubernetes/commit/d30db1f9a915aa95402e1190461469a1889d92be